### PR TITLE
Remove suspend/resume polling functions

### DIFF
--- a/d2l-poller.js
+++ b/d2l-poller.js
@@ -1,5 +1,4 @@
-let poll = false,
-	intervalId;
+let intervalId;
 
 // interval is in ms
 export function setupPolling(interval) {
@@ -10,26 +9,14 @@ export function setupPolling(interval) {
 		teardownPolling();
 	}
 	intervalId = setInterval(() => {
-		if (poll) {
-			const event = new CustomEvent('d2l-poll', {
-				message: 'This is an event from d2l-poller'
-			});
-			dispatchEvent(event);
-		}
+		const event = new CustomEvent('d2l-poll', {
+			message: 'This is an event from d2l-poller'
+		});
+		dispatchEvent(event);
 	}, interval);
-	poll = true;
 }
 
 export function teardownPolling() {
-	poll = false;
 	clearInterval(intervalId);
 	intervalId = undefined;
-}
-
-export function suspendPolling() {
-	poll = false;
-}
-
-export function resumePolling() {
-	poll = true;
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "d2l-poller",
-<<<<<<< Updated upstream
-  "version": "1.0.1",
-=======
   "version": "1.0.2",
->>>>>>> Stashed changes
   "description": "An ES6 module to emit periodic events.",
   "main": "d2l-poller.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "d2l-poller",
+<<<<<<< Updated upstream
   "version": "1.0.1",
+=======
+  "version": "1.0.2",
+>>>>>>> Stashed changes
   "description": "An ES6 module to emit periodic events.",
   "main": "d2l-poller.js",
   "scripts": {


### PR DESCRIPTION
smart-curriculum CI was blowing up because of something in here, so I'm removing stuff to try and fix it